### PR TITLE
Ensure division table contains kits_sent_to_site and add base stylesheet

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,30 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+/* Basic styling for links and tables to ensure page renders decently */
+a {
+    color: #0645AD;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.table th, .table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+
+.table th {
+    background-color: #f2f2f2;
+    text-align: left;
+}


### PR DESCRIPTION
## Summary
- add a utility to guarantee the `kits_sent_to_site` column exists in the `inventory_division` table and call it during initialization and seeding
- provide a basic `style.css` so the app no longer returns 404 for the stylesheet

## Testing
- `python -m py_compile app/models.py init_database.py app/__init__.py app/routes.py app/forms.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4ada1193c8320ad0075a3c54f9506